### PR TITLE
Fix for an issue with https.get() in node v0.6.2

### DIFF
--- a/lib/basecamp.js
+++ b/lib/basecamp.js
@@ -3,7 +3,7 @@ var https = require('https'),
 
 var Basecamp = function (url, key) {
   var self = this;
-  this.host = url;
+  this.host = url.replace('https://','');
   this.key = new Buffer(key + ':X', 'utf8').toString('base64');
 
   this.api = {
@@ -306,7 +306,7 @@ Basecamp.prototype.request = function (path, callback) {
     "path": path,
     "headers": {
       "Authorization": 'Basic ' + this.key,
-      "Host": this.host.replace('https://', ''),
+      "Host": this.host,
       "Accept": 'application/xml',
       "Content-Type": 'application/xml',
       "User-Agent": 'NodeJS'


### PR DESCRIPTION
Hi! Excellent module! Had one tiny issue when using it with node v0.6.2 on Ubuntu 11.10: when following the basic examples, the module would error out at line 31 in dns.js. I tracked it to the https.get() call in request() and played around 'til I found that it worked if I stripped the URI scheme not just in the header but in the top level host property as well. Could have just been me - I'm new to node - but I wasn't doing anything beyond the basic examples in your readme, so I assume maybe it's an issue with my version of node. Pretty simple fix, but thought it might be worth sending back your way in case others encounter the issue. Thanks! -- Alex
